### PR TITLE
v0.6.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,5 @@ tests/js
 .test_results
 
 package-lock.json
+
+.DS_Store

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,12 +15,15 @@
                 "./tests/js/**/*Tests.js"
             ],
             // the below settings are required, otherwise debugging is flaky
-            "protocol": "inspector",
+            // "protocol": "inspector",
             "sourceMaps": true,
             "outFiles": [
                 "dist/**/*.js",
                 "tests/js/**/*.js"
-            ]
+            ],
+            "env": {
+                "TLA_UNDER_TEST": "1"
+            }
         }
     ]
 }

--- a/docs/classes/apiapp.html
+++ b/docs/classes/apiapp.html
@@ -69,7 +69,7 @@
 			<section class="tsd-panel tsd-comment">
 				<div class="tsd-comment tsd-typography">
 					<div class="lead">
-						<p>Application base class which combines the <code>Server</code>, <code>Container</code>(<code>InversifyJS</code>)
+						<p>Application base class which combines the <code>Server</code>, <code>Container</code> (see <code>InversifyJS</code>)
 							and <code>AppConfig</code> classes to create a decorator driven API with typescript
 							middleware and dependency injection. It uses the <code>lambda-api</code> package as the
 						underlying HTTP API framework.</p>
@@ -77,7 +77,7 @@
 					<p>AWS Lambda requests are handled by the <code>run</code> method, which will return a response
 					compatible with either API Gateway or an ALB.</p>
 					<p>Extending this class will allow creating an app implementation for runtimes,
-					AWS Lambda or local web server for example.</p>
+					AWS Lambda, Local Web Server etc.</p>
 				</div>
 			</section>
 			<section class="tsd-panel tsd-hierarchy">
@@ -167,7 +167,7 @@
 									<h5><span class="tsd-flag ts-flagDefault value">Default value</span> appConfig: <a href="appconfig.html" class="tsd-signature-type">AppConfig</a><span class="tsd-signature-symbol"> =&nbsp;new AppConfig()</span></h5>
 									<div class="tsd-comment tsd-typography">
 										<div class="lead">
-											<p>(Optional) Application config to pass to <code>lambda-api</code>.</p>
+											<p>(Optional) Application config to pass to <code>lambda-api</code>, defaults to new <code>AppConfig</code>.</p>
 										</div>
 									</div>
 								</li>
@@ -176,7 +176,8 @@
 									<div class="tsd-comment tsd-typography">
 										<div class="lead">
 											<p>(Optional) <code>InversifyJS</code> IOC <code>Container</code> instance which can
-											build controllers and error interceptors.</p>
+												build controllers and error interceptors, defaults to new <code>Container</code> with
+											<code>autoBindInjectable</code> flag set to `true.</p>
 										</div>
 									</div>
 								</li>
@@ -204,12 +205,12 @@
 					<div class="tsd-signature tsd-kind-icon">app<wbr>Config<span class="tsd-signature-symbol">:</span> <a href="appconfig.html" class="tsd-signature-type">AppConfig</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L46">ApiApp.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L47">ApiApp.ts:47</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
 						<div class="lead">
-							<p>(Optional) Application config to pass to <code>lambda-api</code>.</p>
+							<p>(Optional) Application config to pass to <code>lambda-api</code>, defaults to new <code>AppConfig</code>.</p>
 						</div>
 					</div>
 				</section>
@@ -219,13 +220,14 @@
 					<div class="tsd-signature tsd-kind-icon">app<wbr>Container<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Container</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L47">ApiApp.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L48">ApiApp.ts:48</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
 						<div class="lead">
 							<p>(Optional) <code>InversifyJS</code> IOC <code>Container</code> instance which can
-							build controllers and error interceptors.</p>
+								build controllers and error interceptors, defaults to new <code>Container</code> with
+							<code>autoBindInjectable</code> flag set to `true.</p>
 						</div>
 					</div>
 				</section>
@@ -235,7 +237,7 @@
 					<div class="tsd-signature tsd-kind-icon">controllers<wbr>Path<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L45">ApiApp.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L46">ApiApp.ts:46</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -307,7 +309,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L75">ApiApp.ts:75</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L76">ApiApp.ts:76</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -356,7 +358,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L66">ApiApp.ts:66</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L67">ApiApp.ts:67</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -408,7 +410,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L92">ApiApp.ts:92</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L93">ApiApp.ts:93</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -430,7 +432,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L87">ApiApp.ts:87</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L88">ApiApp.ts:88</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/apilambdaapp.html
+++ b/docs/classes/apilambdaapp.html
@@ -203,12 +203,12 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="apiapp.html">ApiApp</a>.<a href="apiapp.html#appconfig">appConfig</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L46">ApiApp.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L47">ApiApp.ts:47</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
 						<div class="lead">
-							<p>(Optional) Application config to pass to <code>lambda-api</code>.</p>
+							<p>(Optional) Application config to pass to <code>lambda-api</code>, defaults to new <code>AppConfig</code>.</p>
 						</div>
 					</div>
 				</section>
@@ -219,13 +219,14 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="apiapp.html">ApiApp</a>.<a href="apiapp.html#appcontainer">appContainer</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L47">ApiApp.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L48">ApiApp.ts:48</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
 						<div class="lead">
 							<p>(Optional) <code>InversifyJS</code> IOC <code>Container</code> instance which can
-							build controllers and error interceptors.</p>
+								build controllers and error interceptors, defaults to new <code>Container</code> with
+							<code>autoBindInjectable</code> flag set to `true.</p>
 						</div>
 					</div>
 				</section>
@@ -236,7 +237,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="apiapp.html">ApiApp</a>.<a href="apiapp.html#controllerspath">controllersPath</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L45">ApiApp.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L46">ApiApp.ts:46</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -313,7 +314,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="apiapp.html">ApiApp</a>.<a href="apiapp.html#configureapi">configureApi</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L75">ApiApp.ts:75</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L76">ApiApp.ts:76</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -363,7 +364,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="apiapp.html">ApiApp</a>.<a href="apiapp.html#configureapp">configureApp</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L66">ApiApp.ts:66</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L67">ApiApp.ts:67</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -416,7 +417,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="apiapp.html">ApiApp</a>.<a href="apiapp.html#initialisecontrollers">initialiseControllers</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L92">ApiApp.ts:92</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L93">ApiApp.ts:93</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/consolelogger.html
+++ b/docs/classes/consolelogger.html
@@ -167,6 +167,11 @@
 								</li>
 								<li>
 									<h5>logTimestamp: <span class="tsd-signature-type">boolean</span></h5>
+									<div class="tsd-comment tsd-typography">
+										<div class="lead">
+											<p>Print an ISO 8601 timestamp before every log message? (string format only)</p>
+										</div>
+									</div>
 								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <a href="consolelogger.html" class="tsd-signature-type">ConsoleLogger</a></h4>
@@ -183,7 +188,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/ilogger.html">ILogger</a>.<a href="../interfaces/ilogger.html#format">format</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L25">util/logging/ConsoleLogger.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L26">util/logging/ConsoleLogger.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -194,7 +199,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/ilogger.html">ILogger</a>.<a href="../interfaces/ilogger.html#level">level</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L24">util/logging/ConsoleLogger.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L25">util/logging/ConsoleLogger.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -204,9 +209,14 @@
 					<div class="tsd-signature tsd-kind-icon">log<wbr>Timestamp<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L26">util/logging/ConsoleLogger.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L27">util/logging/ConsoleLogger.ts:27</a></li>
 						</ul>
 					</aside>
+					<div class="tsd-comment tsd-typography">
+						<div class="lead">
+							<p>Print an ISO 8601 timestamp before every log message? (string format only)</p>
+						</div>
+					</div>
 				</section>
 			</section>
 			<section class="tsd-panel-group tsd-member-group ">
@@ -222,7 +232,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/ilogger.html">ILogger</a>.<a href="../interfaces/ilogger.html#debug">debug</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L107">util/logging/ConsoleLogger.ts:107</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L108">util/logging/ConsoleLogger.ts:108</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -260,7 +270,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/ilogger.html">ILogger</a>.<a href="../interfaces/ilogger.html#debugenabled">debugEnabled</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L185">util/logging/ConsoleLogger.ts:185</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L186">util/logging/ConsoleLogger.ts:186</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -283,7 +293,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/ilogger.html">ILogger</a>.<a href="../interfaces/ilogger.html#error">error</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L137">util/logging/ConsoleLogger.ts:137</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L138">util/logging/ConsoleLogger.ts:138</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -321,7 +331,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/ilogger.html">ILogger</a>.<a href="../interfaces/ilogger.html#errorenabled">errorEnabled</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L206">util/logging/ConsoleLogger.ts:206</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L207">util/logging/ConsoleLogger.ts:207</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -344,7 +354,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/ilogger.html">ILogger</a>.<a href="../interfaces/ilogger.html#errorwithstack">errorWithStack</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L148">util/logging/ConsoleLogger.ts:148</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L149">util/logging/ConsoleLogger.ts:149</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -388,7 +398,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/ilogger.html">ILogger</a>.<a href="../interfaces/ilogger.html#fatal">fatal</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L158">util/logging/ConsoleLogger.ts:158</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L159">util/logging/ConsoleLogger.ts:159</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -426,7 +436,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/ilogger.html">ILogger</a>.<a href="../interfaces/ilogger.html#fatalenabled">fatalEnabled</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L213">util/logging/ConsoleLogger.ts:213</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L214">util/logging/ConsoleLogger.ts:214</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -449,7 +459,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/ilogger.html">ILogger</a>.<a href="../interfaces/ilogger.html#info">info</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L117">util/logging/ConsoleLogger.ts:117</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L118">util/logging/ConsoleLogger.ts:118</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -487,7 +497,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/ilogger.html">ILogger</a>.<a href="../interfaces/ilogger.html#infoenabled">infoEnabled</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L192">util/logging/ConsoleLogger.ts:192</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L193">util/logging/ConsoleLogger.ts:193</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -510,7 +520,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/ilogger.html">ILogger</a>.<a href="../interfaces/ilogger.html#isoff">isOff</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L220">util/logging/ConsoleLogger.ts:220</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L221">util/logging/ConsoleLogger.ts:221</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -533,7 +543,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/ilogger.html">ILogger</a>.<a href="../interfaces/ilogger.html#levelenabled">levelEnabled</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L167">util/logging/ConsoleLogger.ts:167</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L168">util/logging/ConsoleLogger.ts:168</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -565,7 +575,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/ilogger.html">ILogger</a>.<a href="../interfaces/ilogger.html#log">log</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L54">util/logging/ConsoleLogger.ts:54</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L55">util/logging/ConsoleLogger.ts:55</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -611,7 +621,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/ilogger.html">ILogger</a>.<a href="../interfaces/ilogger.html#trace">trace</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L97">util/logging/ConsoleLogger.ts:97</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L98">util/logging/ConsoleLogger.ts:98</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -649,7 +659,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/ilogger.html">ILogger</a>.<a href="../interfaces/ilogger.html#traceenabled">traceEnabled</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L178">util/logging/ConsoleLogger.ts:178</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L179">util/logging/ConsoleLogger.ts:179</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -672,7 +682,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/ilogger.html">ILogger</a>.<a href="../interfaces/ilogger.html#warn">warn</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L127">util/logging/ConsoleLogger.ts:127</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L128">util/logging/ConsoleLogger.ts:128</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -710,7 +720,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/ilogger.html">ILogger</a>.<a href="../interfaces/ilogger.html#warnenabled">warnEnabled</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L199">util/logging/ConsoleLogger.ts:199</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/ConsoleLogger.ts#L200">util/logging/ConsoleLogger.ts:200</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/controller.html
+++ b/docs/classes/controller.html
@@ -70,7 +70,7 @@
 				<div class="tsd-comment tsd-typography">
 					<div class="lead">
 						<p>Base class for API controllers. Provides access to the
-							current HTTP context as protected fields, and convience
+							current HTTP context as protected fields, and convenience
 						method for applying JSON patches.</p>
 					</div>
 				</div>

--- a/docs/classes/logfactory.html
+++ b/docs/classes/logfactory.html
@@ -150,6 +150,12 @@
 								</li>
 								<li>
 									<h5><span class="tsd-flag ts-flagDefault value">Default value</span> logTimestamp: <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> =&nbsp;false</span></h5>
+									<div class="tsd-comment tsd-typography">
+										<div class="lead">
+											<p>(Optional) Print an ISO 8601 timestamp before every log message?
+											(string format only, defaults to <code>false</code>).</p>
+										</div>
+									</div>
 								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <a href="logfactory.html" class="tsd-signature-type">LogFactory</a></h4>
@@ -169,7 +175,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/LogFactory.ts#L44">util/logging/LogFactory.ts:44</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/LogFactory.ts#L46">util/logging/LogFactory.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -200,7 +206,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/LogFactory.ts#L66">util/logging/LogFactory.ts:66</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/LogFactory.ts#L70">util/logging/LogFactory.ts:70</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -224,6 +230,10 @@
 								</li>
 								<li>
 									<h5><span class="tsd-flag ts-flagDefault value">Default value</span> logTimestamp: <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> =&nbsp;false</span></h5>
+									<div class="tsd-comment tsd-typography">
+										<p>(Optional) Print an ISO 8601 timestamp before every log message?
+										(string format only, defaults to <code>false</code>).</p>
+									</div>
 								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/ilogger.html" class="tsd-signature-type">ILogger</a></h4>
@@ -240,7 +250,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/LogFactory.ts#L53">util/logging/LogFactory.ts:53</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/util/logging/LogFactory.ts#L55">util/logging/LogFactory.ts:55</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/serverloggerconfig.html
+++ b/docs/classes/serverloggerconfig.html
@@ -151,7 +151,7 @@ vvvvvvvvvvvvvvvvvvvvvvvv vvvvv vvvvvvvv   vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 					</aside>
 					<div class="tsd-comment tsd-typography">
 						<div class="lead">
-							<p>Print an ISO 8601 timestamp before every log message.</p>
+							<p>Print an ISO 8601 timestamp before every log message? (string format only)</p>
 						</div>
 						<p>Defaults to false, AWS Lambda already includes timestamps
 						in it&#39;s log of standard output.</p>

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -745,7 +745,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/api/decorator/context/consumes.ts#L14">api/decorator/context/consumes.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/api/decorator/context/consumes.ts#L13">api/decorator/context/consumes.ts:13</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -780,7 +780,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/api/decorator/context/consumes.ts#L43">api/decorator/context/consumes.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/api/decorator/context/consumes.ts#L42">api/decorator/context/consumes.ts:42</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "ts-lambda-api",
   "description": "Build REST API's using Typescript & AWS Lambda. Support for decorator based routing and dependecy injection using InversifyJS. This project is built on top of the wonderful lambda-api package.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/djfdyuruiry/ts-lambda-api.git"
   },
   "scripts": {
     "build": "yarn lint && rm -rf dist && tsc && yarn docs",
-    "build-all": "yarn clean-install && yarn build && yarn build-tests",
+    "build-all": "yarn install && yarn build && yarn build-tests",
     "build-tests": "rm -rf ./tests/js && tsc -p ./tests",
     "clean-install": "rm -rf node_modules && yarn install && yarn improved-audit",
     "docs": "rm -rf ./docs && typedoc --mode file --excludePrivate --sourcefile-url-prefix https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ --out ./docs",

--- a/scripts/runTests.sh
+++ b/scripts/runTests.sh
@@ -8,15 +8,20 @@ codeCoverageReportFile="coverage/index.html"
 
 exitCode=0
 
+# polyfill for realpath command using python
+command -v realpath &> /dev/null || realpath() {
+    python -c "import os; print os.path.abspath('$1')"
+}
+
 printReportSummary() {
     echo
-    echo "TAP File: $(readlink -f ${tapFile})"
+    echo "TAP File: $(realpath ${tapFile})"
 
     if [ -f "${reportFile}" ]; then
-        echo "HTML Test Report: $(readlink -f ${reportFile})"
+        echo "HTML Test Report: $(realpath ${reportFile})"
     fi
 
-    echo "Code Coverage Report: $(readlink -f ${codeCoverageReportFile})"
+    echo "Code Coverage Report: $(realpath ${codeCoverageReportFile})"
     echo
 }
 

--- a/src/ApiApp.ts
+++ b/src/ApiApp.ts
@@ -11,7 +11,7 @@ import { ILogger } from "./util/logging/ILogger"
 import { LogFactory } from "./util/logging/LogFactory"
 
 /**
- * Application base class which combines the `Server`, `Container`(`InversifyJS`)
+ * Application base class which combines the `Server`, `Container` (see `InversifyJS`)
  * and `AppConfig` classes to create a decorator driven API with typescript
  * middleware and dependency injection. It uses the `lambda-api` package as the
  * underlying HTTP API framework.
@@ -20,7 +20,7 @@ import { LogFactory } from "./util/logging/LogFactory"
  * compatible with either API Gateway or an ALB.
  *
  * Extending this class will allow creating an app implementation for runtimes,
- * AWS Lambda or local web server for example.
+ * AWS Lambda, Local Web Server etc.
  */
 export abstract class ApiApp {
     protected readonly apiServer: Server
@@ -37,9 +37,10 @@ export abstract class ApiApp {
      * Create a new app.
      *
      * @param controllersPath Path to a directory containing `js` files containing that declare controllers.
-     * @param appConfig (Optional) Application config to pass to `lambda-api`.
+     * @param appConfig (Optional) Application config to pass to `lambda-api`, defaults to new `AppConfig`.
      * @param appContainer (Optional) `InversifyJS` IOC `Container` instance which can
-     *                     build controllers and error interceptors.
+     *                     build controllers and error interceptors, defaults to new `Container` with
+     *                     `autoBindInjectable` flag set to `true.
      */
     public constructor(
         protected readonly controllersPath: string,

--- a/src/api/Controller.ts
+++ b/src/api/Controller.ts
@@ -7,7 +7,7 @@ import { ILogger } from "../util/logging/ILogger"
 
 /**
  * Base class for API controllers. Provides access to the
- * current HTTP context as protected fields, and convience
+ * current HTTP context as protected fields, and convenience
  * method for applying JSON patches.
  */
 @injectable()

--- a/src/api/decorator/context/consumes.ts
+++ b/src/api/decorator/context/consumes.ts
@@ -1,6 +1,5 @@
 import { inspect } from "util"
 
-import { LogLevel } from "../../../model/logging/LogLevel"
 import { ApiBody } from "../../../model/open-api/ApiBody"
 import { DecoratorRegistry } from "../../reflection/DecoratorRegistry"
 

--- a/src/api/open-api/OpenApiGenerator.ts
+++ b/src/api/open-api/OpenApiGenerator.ts
@@ -338,7 +338,7 @@ export class OpenApiGenerator {
         mediaTypeObject.schema = {}
 
         if (requestInfo.type) {
-            this.addPrimitiveToMediaTypeObject(mediaTypeObject, requestInfo)
+            mediaTypeObject.schema = this.getPrimitiveTypeSchema(requestInfo)
         } else if (requestInfo.class) {
             this.addClassToMediaTypeObject(
                 mediaTypeObject, requestInfo, operationRequestType
@@ -425,7 +425,7 @@ export class OpenApiGenerator {
             if (apiBodyInfo.type) {
                 this.logger.trace("Building response schema from primitive type")
 
-                this.addPrimitiveToMediaTypeObject(mediaTypeObject, apiBodyInfo)
+                mediaTypeObject.schema = this.getPrimitiveTypeSchema(apiBodyInfo)
             } else if (apiBodyInfo.class) {
                 this.logger.trace("Building response schema from class type")
 
@@ -474,26 +474,38 @@ export class OpenApiGenerator {
         }
     }
 
-    private addPrimitiveToMediaTypeObject(mediaTypeObject: MediaTypeObject, apiBodyInfo: ApiBodyInfo) {
-        let type = apiBodyInfo.type.toLowerCase()
+    private getPrimitiveTypeSchema(apiBodyInfo: ApiBodyInfo, instanceType?: string) {
+        let type = instanceType
 
-        if (!OpenApiGenerator.OPEN_API_TYPES.includes(type)) {
-            this.logger.trace("Skipping adding unknown body type to OpenAPI spec: %s", type)
+        if (!type) {
+            type = apiBodyInfo.type.toLowerCase()
 
-            return
+            if (!OpenApiGenerator.OPEN_API_TYPES.includes(type)) {
+                this.logger.trace("Skipping adding unknown body type to OpenAPI spec: %s", type)
+
+                return
+            }
         }
 
         let schemaType = OpenApiGenerator.OPEN_API_SCHEMA_TYPE_MAP[apiBodyInfo.type]
 
         if (type !== "file") {
-            mediaTypeObject.schema = {
+            this.logger.trace("Setting body to type: %s", type)
+
+            let schema = {
                 example: this.getPrimitiveTypeExample(apiBodyInfo.type),
                 type: schemaType
             }
+
+            if (schemaType === "array") {
+                this.addPrimitiveArrayInfoToSchema(schema, apiBodyInfo.type)
+            }
+
+            return schema
         } else {
             this.logger.trace("Setting body to file")
 
-            mediaTypeObject.schema = {
+            return {
                 format: "binary",
                 type: schemaType
             }
@@ -506,6 +518,27 @@ export class OpenApiGenerator {
         this.logger.trace("Adding body example: %s", example)
 
         return toJson(example)
+    }
+
+    private addPrimitiveArrayInfoToSchema(schema: SchemaObject, type: string) {
+        let itemType = type.replace("-array", "")
+        let itemSchemaType = OpenApiGenerator.OPEN_API_SCHEMA_TYPE_MAP[itemType]
+
+        // ensure array items have a type
+        schema.items = {
+            type: itemSchemaType
+        }
+
+        if (itemSchemaType === "object") {
+            // ensure object items can have any properties
+            schema.items.additionalProperties = true
+        } else if (itemSchemaType === "array") {
+            // ensure arrays inside an array have any item types
+            schema.items.items = {
+                additionalProperties: true,
+                type: "object"
+            }
+        }
     }
 
     private addClassToMediaTypeObject(
@@ -528,9 +561,22 @@ export class OpenApiGenerator {
             instance = new clazz()
         }
 
+        let instanceType = "object"
+
+        if (!(instance instanceof clazz)) {
+            instanceType = this.getInstanceType(instance)
+
+            if (!OpenApiGenerator.OPEN_API_TYPES.includes(instanceType)) {
+                // not a supported type or null/undefined, ommit this property
+                this.logger.trace("Ignoring class '%s' as it is of an invalid type: %s",
+                    apiBodyInfo.class.name, instanceType)
+
+                return
+            }
+        }
+
         let schema: SchemaObject = {
-            properties: {},
-            type: "object"
+            type: instanceType
         }
 
         mediaTypeObject.schema = schema
@@ -544,7 +590,22 @@ export class OpenApiGenerator {
             schema.example = exampleJson
         }
 
-        this.addObjectPropertiesToSchema(mediaTypeObject.schema, instance)
+        if (instanceType === "object") {
+            this.addObjectPropertiesToSchema(schema, instance)
+        } else if (instanceType === "array") {
+            if (instance.length > 0) {
+                this.addArrayToSchema(schema, instance)
+            } else {
+                this.logger.trace("Ignoring class '%s' array as it has no items in it's example",
+                    apiBodyInfo.class.name)
+
+                delete mediaTypeObject.schema
+                return
+            }
+        } else {
+            schema.example = instance
+            mediaTypeObject.example = instance
+        }
     }
 
     private addObjectPropertiesToSchema(schema: SchemaObject, instance: any) {
@@ -555,6 +616,8 @@ export class OpenApiGenerator {
 
             if (!OpenApiGenerator.OPEN_API_TYPES.includes(type)) {
                 // not a supported type or null/undefined, ommit this property
+                this.logger.trace("Ignoring property '%s' as it is of an invalid type: %s", property, type)
+
                 continue
             }
 

--- a/src/api/open-api/OpenApiGenerator.ts
+++ b/src/api/open-api/OpenApiGenerator.ts
@@ -474,20 +474,16 @@ export class OpenApiGenerator {
         }
     }
 
-    private getPrimitiveTypeSchema(apiBodyInfo: ApiBodyInfo, instanceType?: string) {
-        let type = instanceType
+    private getPrimitiveTypeSchema(apiBodyInfo: ApiBodyInfo) {
+        let type = apiBodyInfo.type.toLowerCase()
 
-        if (!type) {
-            type = apiBodyInfo.type.toLowerCase()
+        if (!OpenApiGenerator.OPEN_API_TYPES.includes(type)) {
+            this.logger.trace("Skipping adding unknown body type to OpenAPI spec: %s", type)
 
-            if (!OpenApiGenerator.OPEN_API_TYPES.includes(type)) {
-                this.logger.trace("Skipping adding unknown body type to OpenAPI spec: %s", type)
-
-                return
-            }
+            return
         }
 
-        let schemaType = OpenApiGenerator.OPEN_API_SCHEMA_TYPE_MAP[apiBodyInfo.type]
+        let schemaType = OpenApiGenerator.OPEN_API_SCHEMA_TYPE_MAP[type]
 
         if (type !== "file") {
             this.logger.trace("Setting body to type: %s", type)

--- a/src/model/logging/ServerLoggerConfig.ts
+++ b/src/model/logging/ServerLoggerConfig.ts
@@ -13,7 +13,7 @@ export class ServerLoggerConfig {
     public level: LogLevel
 
     /**
-     * Print an ISO 8601 timestamp before every log message.
+     * Print an ISO 8601 timestamp before every log message? (string format only)
      *
      * Defaults to false, AWS Lambda already includes timestamps
      * in it's log of standard output.

--- a/src/util/logging/ConsoleLogger.ts
+++ b/src/util/logging/ConsoleLogger.ts
@@ -18,6 +18,7 @@ export class ConsoleLogger implements ILogger {
      * @param clazz The enclosing class that will use the new logger.
      * @param logLevel Lowest level to log, defaults to `info`.
      * @param logFormat Format to output log messages in, defaults to `string`.
+     * @param logTimestamp Print an ISO 8601 timestamp before every log message? (string format only)
      */
     public constructor(
         private readonly clazz: string,

--- a/src/util/logging/LogFactory.ts
+++ b/src/util/logging/LogFactory.ts
@@ -13,6 +13,8 @@ export class LogFactory {
      * @param appConfig Config object to read logging config from.
      * @param logLevel (Optional) Lowest level to log, defaults to `info`.
      * @param logFormat (Optional) Format to output log messages in, defaults to `string`.
+     * @param logTimestamp (Optional) Print an ISO 8601 timestamp before every log message?
+     *                     (string format only, defaults to `false`).
      */
     public constructor(
         appConfig: AppConfig,
@@ -62,6 +64,8 @@ export class LogFactory {
      * @param clazz The enclosing class that will use the new logger.
      * @param logLevel (Optional) Lowest level to log, defaults to `info`.
      * @param logFormat (Optional) Format to output log messages in, defaults to `string`.
+     * @param logTimestamp (Optional) Print an ISO 8601 timestamp before every log message?
+     *                     (string format only, defaults to `false`).
      */
     public static getCustomLogger(
         clazz: Function,

--- a/tests/src/OpenApiTests.ts
+++ b/tests/src/OpenApiTests.ts
@@ -11,7 +11,7 @@ import { TestCustomAuthFilter } from "./test-components/TestCustomAuthFilter";
 
 @TestFixture()
 export class OpenApiTests extends TestBase {
-    private static readonly ROUTE_COUNT = 45
+    private static readonly ROUTE_COUNT = 49
     private static readonly HTTP_METHODS = ["get", "put", "post", "delete", "options", "head", "patch", "trace"]
 
     @AsyncSetup
@@ -528,6 +528,47 @@ export class OpenApiTests extends TestBase {
     @TestCase("json")
     @TestCase("yml")
     @AsyncTest()
+    public async when_openapi_enabled_then_openapi_spec_contains_response_schema_for_primitive_class_examples(specFormat: string) {
+        let endpoint = await this.getOpenApiEndpoint(specFormat, "/test/open-api/primitive-class-example", "get")
+        let response: ResponseObject = endpoint.responses["200"]
+        let content: MediaTypeObject = response.content["application/json"]
+        let schema: SchemaObject = content.schema
+
+        Expect(content.example).toEqual(30)
+
+        Expect(schema.type).toEqual("number")
+        Expect(schema.example).toEqual(30)
+    }
+
+    @TestCase("json")
+    @TestCase("yml")
+    @AsyncTest()
+    public async when_openapi_enabled_then_openapi_spec_contains_response_schema_for_primitive_class_array_examples(specFormat: string) {
+        let endpoint = await this.getOpenApiEndpoint(specFormat, "/test/open-api/primitive-array-class-example", "get")
+        let response: ResponseObject = endpoint.responses["200"]
+        let content: MediaTypeObject = response.content["application/json"]
+        let schema: SchemaObject = content.schema
+
+        Expect(content.example).toEqual(`[
+  "a",
+  "b"
+]`)
+
+        Expect(schema.type).toEqual("array")
+        Expect(schema.example).toEqual(`[
+  "a",
+  "b"
+]`)
+
+        let itemSchema = schema.items as SchemaObject
+
+        Expect(itemSchema.type).toEqual("string")
+        Expect(itemSchema.example).toEqual("a")
+    }
+
+    @TestCase("json")
+    @TestCase("yml")
+    @AsyncTest()
     public async when_openapi_enabled_then_openapi_spec_contains_custom_response_examples(specFormat: string) {
         let endpoint = await this.getOpenApiEndpoint(specFormat, "/test/open-api/custom-info", "post")
         let response_201: ResponseObject = endpoint.responses["201"]
@@ -659,6 +700,159 @@ export class OpenApiTests extends TestBase {
             "items": {
                 "type": "string",
                 "example": "a"
+            }
+        })
+    }
+
+    @TestCase("json")
+    @TestCase("yml")
+    @AsyncTest()
+    public async when_openapi_enabled_then_openapi_spec_contains_schemas_with_example_object_array_types_at_root(specFormat: string) {
+        let endpoint = await this.getOpenApiEndpoint(specFormat, "/test/open-api/example-array-objects", "get")
+        let response = endpoint.responses["200"] as ResponseObject
+        let content = response.content["application/json"]
+        let schema = content.schema as SchemaObject
+
+        Expect(schema.type).toEqual("array")
+        Expect(schema.example).toEqual(`[
+  {},
+  {},
+  {}
+]`)
+
+        let arrayItemsSchema = schema.items as SchemaObject
+
+        Expect(arrayItemsSchema.type).toEqual("object")
+        Expect(arrayItemsSchema.additionalProperties).toEqual(true)
+    }
+
+    @TestCase("json")
+    @TestCase("yml")
+    @AsyncTest()
+    public async when_openapi_enabled_then_openapi_spec_contains_schemas_with_object_array_types_at_root(specFormat: string) {
+        let endpoint = await this.getOpenApiEndpoint(specFormat, "/test/open-api/array-objects", "get")
+        let response = endpoint.responses["200"] as ResponseObject
+        let content = response.content["application/json"]
+        let schema = content.schema as SchemaObject
+
+        Expect(schema.type).toEqual("array")
+
+        Expect(schema.example).toEqual(`[
+  {
+    "name": "name",
+    "age": 18,
+    "location": {
+      "city": "city",
+      "country": "country",
+      "localeCodes": [
+        10,
+        20,
+        30
+      ]
+    },
+    "roles": [
+      "role1",
+      "role2",
+      "roleN"
+    ]
+  },
+  {
+    "name": "name",
+    "age": 18,
+    "location": {
+      "city": "city",
+      "country": "country",
+      "localeCodes": [
+        10,
+        20,
+        30
+      ]
+    },
+    "roles": [
+      "role1",
+      "role2",
+      "roleN"
+    ]
+  },
+  {
+    "name": "name",
+    "age": 18,
+    "location": {
+      "city": "city",
+      "country": "country",
+      "localeCodes": [
+        10,
+        20,
+        30
+      ]
+    },
+    "roles": [
+      "role1",
+      "role2",
+      "roleN"
+    ]
+  }
+]`)
+
+        let arrayItemsSchema = schema.items as SchemaObject
+
+        Expect(arrayItemsSchema.type).toEqual("object")
+        Expect(arrayItemsSchema.example).toEqual(`{
+  "name": "name",
+  "age": 18,
+  "location": {
+    "city": "city",
+    "country": "country",
+    "localeCodes": [
+      10,
+      20,
+      30
+    ]
+  },
+  "roles": [
+    "role1",
+    "role2",
+    "roleN"
+  ]
+}`)
+        Expect(arrayItemsSchema.properties).toEqual({
+            "name": {
+                "type": "string",
+                "example": "name"
+            },
+            "age": {
+                "type": "number",
+                "example": 18
+            },
+            "location": {
+                "type": "object",
+                "example": "{\n  \"city\": \"city\",\n  \"country\": \"country\",\n  \"localeCodes\": [\n    10,\n    20,\n    30\n  ]\n}",
+                "properties": {
+                    "city": {
+                        "type": "string",
+                        "example": "city"
+                    },
+                    "country": {
+                        "type": "string",
+                        "example": "country"
+                    },
+                    "localeCodes": {
+                        "type": "array",
+                        "example": "[\n  10,\n  20,\n  30\n]",
+                        "items": {
+                            "type": "number",
+                            "example": 10
+                        }
+                    }
+                }
+            },
+            "roles": {
+                "type": "array",
+                "example": "[\n  \"role1\",\n  \"role2\",\n  \"roleN\"\n]",
+                "items": {
+                    "type": "string",
+                    "example": "role1"
+                }
             }
         })
     }

--- a/tests/src/test-components/model/ArrayOfPrimitivesExample.ts
+++ b/tests/src/test-components/model/ArrayOfPrimitivesExample.ts
@@ -1,0 +1,8 @@
+export class ArrayofPrimitivesExample {
+    public static example() {
+        return [
+            "a",
+            "b"
+        ]
+    }
+}

--- a/tests/src/test-components/model/People.ts
+++ b/tests/src/test-components/model/People.ts
@@ -1,0 +1,11 @@
+import { Person } from "./Person"
+
+export class People {
+    public static example() {
+        return [
+            Person.example(),
+            Person.example(),
+            Person.example()
+        ]
+    }
+}

--- a/tests/src/test-components/model/PrimitiveExample.ts
+++ b/tests/src/test-components/model/PrimitiveExample.ts
@@ -1,0 +1,5 @@
+export class PrimitiveExample {
+    public static example() {
+        return 30
+    }
+}

--- a/tests/src/test-controllers/OpenApiTestController.ts
+++ b/tests/src/test-controllers/OpenApiTestController.ts
@@ -3,9 +3,12 @@ import { injectable } from "inversify"
 import { api, apiController, apiOperation, apiRequest, apiResponse, body, rawBody, Controller, JsonPatch, GET, POST, PUT, PATCH, DELETE} from "../../../dist/ts-lambda-api"
 
 import { ApiError } from "../test-components/model/ApiError"
+import { ArrayofPrimitivesExample } from '../test-components/model/ArrayOfPrimitivesExample'
 import { ConstructorOnlyModel } from "../test-components/model/ConstructorOnlyModel"
+import { EdgeCaseModel } from "../test-components/model/EdgeCaseModel"
+import { People } from "../test-components/model/People"
 import { Person } from "../test-components/model/Person"
-import { EdgeCaseModel } from "../test-components/model/EdgeCaseModel";
+import { PrimitiveExample } from '../test-components/model/PrimitiveExample'
 
 @apiController("/test/open-api")
 @api("Open API Test", "Endpoints with OpenAPI decorators")
@@ -16,6 +19,34 @@ export class OpenApiTestControllerController extends Controller {
     @apiResponse(200, {type: "string"})
     public get() {
         return "OK"
+    }
+
+    @GET("/example-array-objects")
+    @apiOperation({ name: "get example array of objects", description: "go get example array of objects"})
+    @apiResponse(200, {type: "object-array", example: `[{"age":23,"name":"carlos","gender":"male","city":"Dubai"},{"age":24,"name":"carlos","gender":"male","city":"Dubai"},{"age":25,"name":"carlos","gender":"male","city":"Dubai"}]` })
+    public getExampleArrayOfObjects() {
+        return [{"age":23,"name":"carlos","gender":"male","city":"Dubai"},{"age":24,"name":"carlos","gender":"male","city":"Dubai"},{"age":25,"name":"carlos","gender":"male","city":"Dubai"}]
+    }
+
+    @GET("/primitive-class-example")
+    @apiOperation({ name: "get primitive class example", description: "go get primitive class example"})
+    @apiResponse(200, { class: PrimitiveExample })
+    public getPrimitiveClassExample() {
+        return PrimitiveExample.example()
+    }
+
+    @GET("/primitive-array-class-example")
+    @apiOperation({ name: "get primitive array class example", description: "go get primitive array class example"})
+    @apiResponse(200, { class: ArrayofPrimitivesExample })
+    public getPrimitiveArrayClassExample() {
+        return ArrayofPrimitivesExample.example()
+    }
+
+    @GET("/array-objects")
+    @apiOperation({ name: "get array of objects", description: "go get array of objects"})
+    @apiResponse(200, { class: People })
+    public getArrayOfObjects() {
+        return People.example()
     }
 
     @GET("/constructor")


### PR DESCRIPTION
- Documentation Updates
- Fixing issue #17 reported by @jearles 
  - Array types for custom example types did not have an `items` field in the schema
- Support for non-object types in example methods for OpenAPI examples
- Preventing authentication info being logged