### PR TITLE
Don't load controllers when autoBindInjectable is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This project is built on top of the wonderful [lambda-api](https://github.com/je
     - [Controller Routes](#controller-routes)
     - [Endpoint Routes](#endpoint-routes)
     - [Path Parameters](#path-params)
+    - [Manually Loading Controllers](#loading-controllers)
 - [Request Parameter Binding](#request-binding)
 - [Responses](#responses)
 - [Authentication & Authorization](#auth-authorization)
@@ -333,6 +334,45 @@ export class StoreController {
 ```
 
 **Note all path parameters are passed in as strings, you will need to cast these if required**
+
+---
+
+### <a id="loading-controllers"></a>Manually Loading Controllers
+
+---
+
+The default IOC app `Container` enables the `autoBindInjectable` option. Controllers decorated with
+`@injectable` are dynamicallly loaded from the required `controllersPath` directory during 
+initialisation. However, controllers can be explicity specified instead of relying on the `@injectable` 
+decoration to dynamically load the controllers from a directory.
+
+Create an IOC `Container` with the `autoBindInjectable` option disabled. Bind the desired controller 
+classes to the container and pass the instance into the `ApiLambdaApp` constructor. The `controllersPath`
+parameter is ignored when the custom container's `autoBindInjectable` option disabled.
+
+```typescript
+import { Container } from 'inversify';
+import { ApiLambdaApp, ApiRequest, AppConfig } from 'ts-lambda-api';
+import { AppController } from './controllers/AppController';
+
+const appConfig = new AppConfig();
+appConfig.base = '/api/v1';
+appConfig.version = 'v1';
+
+// Bind the controllers to a container instance with @injectable disabled
+const appContainer = new Container({ autoBindInjectable: false });
+const appController = new AppController();
+appContainer.bind(AppController).toConstantValue(appController);
+
+// Pass the customer container into the app - controllersPath is ignored
+const app = new ApiLambdaApp(undefined, appConfig, appContainer);
+
+export const lambdaHandler = async (event: ApiRequest, context: any) => {
+	return await app.run(event, context);
+};
+```
+
+**Note you do not need to decorate controller classes with @injectable when autoBindInjectable is disabled**
 
 ----
 

--- a/docs/classes/apiapp.html
+++ b/docs/classes/apiapp.html
@@ -139,7 +139,7 @@
 					<a name="constructor" class="tsd-anchor"></a>
 					<h3>constructor</h3>
 					<ul class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">new <wbr>Api<wbr>App<span class="tsd-signature-symbol">(</span>controllersPath<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, appConfig<span class="tsd-signature-symbol">?: </span><a href="appconfig.html" class="tsd-signature-type">AppConfig</a>, appContainer<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">Container</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="apiapp.html" class="tsd-signature-type">ApiApp</a></li>
+						<li class="tsd-signature tsd-kind-icon">new <wbr>Api<wbr>App<span class="tsd-signature-symbol">(</span>controllersPath<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, appConfig<span class="tsd-signature-symbol">?: </span><a href="appconfig.html" class="tsd-signature-type">AppConfig</a>, appContainer<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">Container</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="apiapp.html" class="tsd-signature-type">ApiApp</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -156,10 +156,14 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>controllersPath: <span class="tsd-signature-type">string</span></h5>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> controllersPath: <span class="tsd-signature-type">string</span></h5>
 									<div class="tsd-comment tsd-typography">
 										<div class="lead">
-											<p>Path to a directory containing <code>js</code> files containing that declare controllers.</p>
+											<p>(Optional) Path to a directory containing <code>js</code> files that declare
+												controllers. Required if the default <code>Container</code> is used, or the provided
+												<code>Container</code> instance has its <code>autoBindInjectable</code> flag set to <code>true</code>.
+												Ignored if the provided <code>Container</code> instance has its <code>autoBindInjectable</code>
+											flag set to <code>false</code>.</p>
 										</div>
 									</div>
 								</li>
@@ -177,7 +181,7 @@
 										<div class="lead">
 											<p>(Optional) <code>InversifyJS</code> IOC <code>Container</code> instance which can
 												build controllers and error interceptors, defaults to new <code>Container</code> with
-											<code>autoBindInjectable</code> flag set to `true.</p>
+											<code>autoBindInjectable</code> flag set to <code>true</code>.</p>
 										</div>
 									</div>
 								</li>
@@ -205,7 +209,7 @@
 					<div class="tsd-signature tsd-kind-icon">app<wbr>Config<span class="tsd-signature-symbol">:</span> <a href="appconfig.html" class="tsd-signature-type">AppConfig</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L47">ApiApp.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L51">ApiApp.ts:51</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -220,29 +224,33 @@
 					<div class="tsd-signature tsd-kind-icon">app<wbr>Container<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Container</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L48">ApiApp.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L52">ApiApp.ts:52</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
 						<div class="lead">
 							<p>(Optional) <code>InversifyJS</code> IOC <code>Container</code> instance which can
 								build controllers and error interceptors, defaults to new <code>Container</code> with
-							<code>autoBindInjectable</code> flag set to `true.</p>
+							<code>autoBindInjectable</code> flag set to <code>true</code>.</p>
 						</div>
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-protected">
 					<a name="controllerspath" class="tsd-anchor"></a>
-					<h3><span class="tsd-flag ts-flagProtected">Protected</span> <span class="tsd-flag ts-flagReadonly">Readonly</span> controllers<wbr>Path</h3>
+					<h3><span class="tsd-flag ts-flagProtected">Protected</span> <span class="tsd-flag ts-flagOptional">Optional</span> <span class="tsd-flag ts-flagReadonly">Readonly</span> controllers<wbr>Path</h3>
 					<div class="tsd-signature tsd-kind-icon">controllers<wbr>Path<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L46">ApiApp.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L50">ApiApp.ts:50</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
 						<div class="lead">
-							<p>Path to a directory containing <code>js</code> files containing that declare controllers.</p>
+							<p>(Optional) Path to a directory containing <code>js</code> files that declare
+								controllers. Required if the default <code>Container</code> is used, or the provided
+								<code>Container</code> instance has its <code>autoBindInjectable</code> flag set to <code>true</code>.
+								Ignored if the provided <code>Container</code> instance has its <code>autoBindInjectable</code>
+							flag set to <code>false</code>.</p>
 						</div>
 					</div>
 				</section>
@@ -309,7 +317,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L76">ApiApp.ts:76</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L80">ApiApp.ts:80</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -358,7 +366,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L67">ApiApp.ts:67</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L71">ApiApp.ts:71</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -410,7 +418,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L93">ApiApp.ts:93</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L97">ApiApp.ts:97</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -432,7 +440,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L88">ApiApp.ts:88</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L92">ApiApp.ts:92</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/apilambdaapp.html
+++ b/docs/classes/apilambdaapp.html
@@ -135,7 +135,7 @@
 					<a name="constructor" class="tsd-anchor"></a>
 					<h3>constructor</h3>
 					<ul class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class tsd-is-overwrite">
-						<li class="tsd-signature tsd-kind-icon">new <wbr>Api<wbr>Lambda<wbr>App<span class="tsd-signature-symbol">(</span>controllersPath<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, appConfig<span class="tsd-signature-symbol">?: </span><a href="appconfig.html" class="tsd-signature-type">AppConfig</a>, appContainer<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">Container</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="apilambdaapp.html" class="tsd-signature-type">ApiLambdaApp</a></li>
+						<li class="tsd-signature tsd-kind-icon">new <wbr>Api<wbr>Lambda<wbr>App<span class="tsd-signature-symbol">(</span>controllersPath<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, appConfig<span class="tsd-signature-symbol">?: </span><a href="appconfig.html" class="tsd-signature-type">AppConfig</a>, appContainer<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">Container</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="apilambdaapp.html" class="tsd-signature-type">ApiLambdaApp</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -153,10 +153,14 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>controllersPath: <span class="tsd-signature-type">string</span></h5>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> controllersPath: <span class="tsd-signature-type">string</span></h5>
 									<div class="tsd-comment tsd-typography">
 										<div class="lead">
-											<p>Path to the directory containing controller <code>js</code> files.</p>
+											<p>(Optional) Path to the directory containing controller <code>js</code> files.
+												Required if the default <code>Container</code> is used, or the provided
+												<code>Container</code> instance has its <code>autoBindInjectable</code> flag set to <code>true</code>.
+												Ignored if the provided <code>Container</code> instance has its <code>autoBindInjectable</code>
+											flag set to <code>false</code>.</p>
 										</div>
 									</div>
 								</li>
@@ -203,7 +207,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="apiapp.html">ApiApp</a>.<a href="apiapp.html#appconfig">appConfig</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L47">ApiApp.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L51">ApiApp.ts:51</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -219,30 +223,34 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="apiapp.html">ApiApp</a>.<a href="apiapp.html#appcontainer">appContainer</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L48">ApiApp.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L52">ApiApp.ts:52</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
 						<div class="lead">
 							<p>(Optional) <code>InversifyJS</code> IOC <code>Container</code> instance which can
 								build controllers and error interceptors, defaults to new <code>Container</code> with
-							<code>autoBindInjectable</code> flag set to `true.</p>
+							<code>autoBindInjectable</code> flag set to <code>true</code>.</p>
 						</div>
 					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-protected">
 					<a name="controllerspath" class="tsd-anchor"></a>
-					<h3><span class="tsd-flag ts-flagProtected">Protected</span> <span class="tsd-flag ts-flagReadonly">Readonly</span> controllers<wbr>Path</h3>
+					<h3><span class="tsd-flag ts-flagProtected">Protected</span> <span class="tsd-flag ts-flagOptional">Optional</span> <span class="tsd-flag ts-flagReadonly">Readonly</span> controllers<wbr>Path</h3>
 					<div class="tsd-signature tsd-kind-icon">controllers<wbr>Path<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="apiapp.html">ApiApp</a>.<a href="apiapp.html#controllerspath">controllersPath</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L46">ApiApp.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L50">ApiApp.ts:50</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
 						<div class="lead">
-							<p>Path to a directory containing <code>js</code> files containing that declare controllers.</p>
+							<p>(Optional) Path to a directory containing <code>js</code> files that declare
+								controllers. Required if the default <code>Container</code> is used, or the provided
+								<code>Container</code> instance has its <code>autoBindInjectable</code> flag set to <code>true</code>.
+								Ignored if the provided <code>Container</code> instance has its <code>autoBindInjectable</code>
+							flag set to <code>false</code>.</p>
 						</div>
 					</div>
 				</section>
@@ -314,7 +322,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="apiapp.html">ApiApp</a>.<a href="apiapp.html#configureapi">configureApi</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L76">ApiApp.ts:76</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L80">ApiApp.ts:80</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -364,7 +372,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="apiapp.html">ApiApp</a>.<a href="apiapp.html#configureapp">configureApp</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L67">ApiApp.ts:67</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L71">ApiApp.ts:71</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -417,7 +425,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="apiapp.html">ApiApp</a>.<a href="apiapp.html#initialisecontrollers">initialiseControllers</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L93">ApiApp.ts:93</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts#L97">ApiApp.ts:97</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -440,7 +448,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="apiapp.html">ApiApp</a>.<a href="apiapp.html#run">run</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiLambdaApp.ts#L38">ApiLambdaApp.ts:38</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiLambdaApp.ts#L42">ApiLambdaApp.ts:42</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/server.html
+++ b/docs/classes/server.html
@@ -233,13 +233,13 @@
 					<a name="discoverandbuildroutes" class="tsd-anchor"></a>
 					<h3>discover<wbr>And<wbr>Build<wbr>Routes</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">discover<wbr>And<wbr>Build<wbr>Routes<span class="tsd-signature-symbol">(</span>controllersPath<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">discover<wbr>And<wbr>Build<wbr>Routes<span class="tsd-signature-symbol">(</span>controllersPath<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/api/Server.ts#L84">api/Server.ts:84</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/api/Server.ts#L87">api/Server.ts:87</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -260,9 +260,12 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>controllersPath: <span class="tsd-signature-type">string</span></h5>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> controllersPath: <span class="tsd-signature-type">string</span></h5>
 									<div class="tsd-comment tsd-typography">
-										<p>Path to the directory containing controller <code>js</code> files.</p>
+										<p>(Optional) Path to the directory containing controller <code>js</code> files.
+											Dynamic loading of <code>injectable</code> controllers is disabled if undefined
+											or the app <code>Container</code> instance has its <code>autoBindInjectable</code>
+										flag set to <code>false</code>.</p>
 									</div>
 								</li>
 							</ul>
@@ -280,7 +283,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/api/Server.ts#L144">api/Server.ts:144</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/api/Server.ts#L150">api/Server.ts:150</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/src/ApiApp.ts
+++ b/src/ApiApp.ts
@@ -36,18 +36,22 @@ export abstract class ApiApp {
     /**
      * Create a new app.
      *
-     * @param controllersPath Path to a directory containing `js` files containing that declare controllers.
+     * @param controllersPath (Optional) Path to a directory containing `js` files that declare
+     *                        controllers. Required if the default `Container` is used, or the provided
+     *                        `Container` instance has its `autoBindInjectable` flag set to `true`.
+     *                        Ignored if the provided `Container` instance has its `autoBindInjectable`
+     *                        flag set to `false`.
      * @param appConfig (Optional) Application config to pass to `lambda-api`, defaults to new `AppConfig`.
      * @param appContainer (Optional) `InversifyJS` IOC `Container` instance which can
      *                     build controllers and error interceptors, defaults to new `Container` with
-     *                     `autoBindInjectable` flag set to `true.
+     *                     `autoBindInjectable` flag set to `true`.
      */
     public constructor(
-        protected readonly controllersPath: string,
+        protected readonly controllersPath?: string,
         protected appConfig: AppConfig = new AppConfig(),
         protected appContainer: Container = new Container({ autoBindInjectable: true })
     ) {
-        if (!controllersPath || controllersPath.trim() === "") {
+        if (appContainer.options.autoBindInjectable && (!controllersPath || controllersPath.trim() === "")) {
             throw new Error("Null, empty or whitespace controllersPath passed to ApiApp")
         }
         appContainer.bind(AppConfig).toConstantValue(this.appConfig)

--- a/src/ApiLambdaApp.ts
+++ b/src/ApiLambdaApp.ts
@@ -16,12 +16,16 @@ export class ApiLambdaApp extends ApiApp {
     /**
      * Create a new lambda app.
      *
-     * @param controllersPath Path to the directory containing controller `js` files.
+     * @param controllersPath (Optional) Path to the directory containing controller `js` files.
+     *                        Required if the default `Container` is used, or the provided
+     *                        `Container` instance has its `autoBindInjectable` flag set to `true`.
+     *                        Ignored if the provided `Container` instance has its `autoBindInjectable`
+     *                        flag set to `false`.
      * @param appConfig (Optional) Application config to pass to `lambda-api`.
      * @param appContainer (Optional) `InversifyJS` IOC `Container` instance which can build
      *                     controllers and error interceptors.
      */
-    public constructor(controllersPath: string, appConfig?: AppConfig, appContainer?: Container) {
+    public constructor(controllersPath?: string, appConfig?: AppConfig, appContainer?: Container) {
         super(controllersPath, appConfig, appContainer)
 
         this.logger = this.logFactory.getLogger(ApiLambdaApp)

--- a/src/api/Server.ts
+++ b/src/api/Server.ts
@@ -78,13 +78,19 @@ export class Server {
      *
      * This method must be called before invoking the `processEvent` method.
      *
-     * @param controllersPath Path to the directory containing controller `js` files.
+     * @param controllersPath (Optional) Path to the directory containing controller `js` files.
+     *                        Dynamic loading of `injectable` controllers is disabled if undefined
+     *                        or the app `Container` instance has its `autoBindInjectable`
+     *                        flag set to `false`.
      */
     @timed
-    public async discoverAndBuildRoutes(controllersPath: string) {
-        this.logger.debug("Loading controllers from path: %s", controllersPath)
-
-        await ControllerLoader.loadControllers(controllersPath, this.logFactory)
+    public async discoverAndBuildRoutes(controllersPath?: string) {
+        if (this.appContainer.options.autoBindInjectable && controllersPath) {
+            this.logger.debug("Loading controllers from path: %s", controllersPath)
+            await ControllerLoader.loadControllers(controllersPath, this.logFactory)
+        } else {
+            this.logger.debug("Dynamic loading of injectable controllers disabled")
+        }
 
         if (this.openApiGenerator) {
             this.registerOpenApiEndpoints()

--- a/tests/src/ApiLambdaAppTests.ts
+++ b/tests/src/ApiLambdaAppTests.ts
@@ -40,6 +40,70 @@ export class ApiLambdaAppTests extends TestBase {
     }
 
     @Test()
+    public async when_default_app_container_then_contoller_path_must_be_valid() {
+         Expect(() => new ApiLambdaApp(
+            "  ",
+            this.appConfig
+        )).toThrow()
+    }
+
+    @Test()
+    public async when_default_app_container_then_contoller_path_is_required() {
+        Expect(() => new ApiLambdaApp(
+            undefined,
+            this.appConfig
+        )).toThrow()
+    }
+
+    @Test()
+    public async when_custom_container_passed_to_app_with_auto_bind_injectable_enabled_then_contoller_path_must_be_valid() {
+        let container = new Container({ autoBindInjectable: true })
+
+        Expect(() => new ApiLambdaApp(
+            "  ",
+            this.appConfig,
+            container
+        )).toThrow()
+    }
+
+    @Test()
+    public async when_custom_container_passed_to_app_with_auto_bind_injectable_enabled_then_contoller_path_is_required() {
+        let container = new Container({ autoBindInjectable: true })
+
+        Expect(() => new ApiLambdaApp(
+            undefined,
+            this.appConfig,
+            container
+        )).toThrow()
+    }
+
+    @Test()
+    public async when_custom_container_passed_to_app_with_auto_bind_injectable_disabled_then_contoller_path_can_be_undefined() {
+        let container = new Container({ autoBindInjectable: false })
+
+        let app = new ApiLambdaApp(
+            undefined,
+            this.appConfig,
+            container
+        )
+
+        app.configureApp(c => Expect(c).toBe(container))
+    }
+
+    @Test()
+    public async when_custom_container_passed_to_app_with_auto_bind_injectable_disabled_then_contoller_path_ignored() {
+        let container = new Container({ autoBindInjectable: false })
+
+        let app = new ApiLambdaApp(
+            " ",
+            this.appConfig,
+            container
+        )
+
+        app.configureApp(c => Expect(c).toBe(container))
+    }
+
+    @Test()
     public async when_api_is_configured_using_app_then_configuration_is_respected() {
         this.app.configureApi(a => a.get("/manual-endpoint", (_, res) => {
             res.send("OK")


### PR DESCRIPTION
- make  ApiLambdaApp constructor's contollersPath input optional
- ignore controllersPath constructor input when ApiLambdaApp appContainer has autoBindInjectable disabled
- dynamically load  controllers only when appContainer has autoBindInjectable enabled
- add section to README.md describing how to manually load controllers into an IOC container
- add unit test to verify behaviour of the ApiLambdaApp constructor's optional controllersPath input