### PR TITLE
Add annotations to hide endpoints from OpenAPI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1469,6 +1469,27 @@ To further document your API endpoints you can use OpenAPI decorators.
     }
     ```
 
+- Hide controllers or individual endpoints from the documentation with `apiIgnoreController` and `apiIgnore`:
+
+    ```typescript
+    import { injectable } from "inversify"
+    import { api, apiController } from "ts-lambda-api"
+
+    @apiController("/private")
+    @api("Private API", "You can still annotate these")
+    @apiIgnoreController()
+    @injectable()
+    export class PrivateController {
+    
+      @GET()
+      @apiOperation({ name: "get stuff", description: "go get some stuff"})
+      @apiIgnore() // if you didn't want to ignore the whole controller
+      public get() {
+          return "OK"
+      }
+    }
+    ```
+
     The class `Person` is set as the request and response in several of the examples above. To help the framework provide meaningful request and response examples automatically, you must either:
 
     1. Provide a public static `example` method in your class, which will be called if found when generating an API spec. (recommended)

--- a/src/api/decorator/open-api/apiIgnore.ts
+++ b/src/api/decorator/open-api/apiIgnore.ts
@@ -1,0 +1,23 @@
+import { DecoratorRegistry } from "../../reflection/DecoratorRegistry"
+
+/**
+ * Decorator that can be placed on an endpoint to describe it in any generated
+ * OpenAPI specification.
+ *
+ * @param apiOperationInfo Information about this api operation; will be merged with
+ *                         existing info if present, replacing any existing properties,
+ *                         if provided in this parameter.
+ */
+export function apiIgnore() {
+    return (classDefinition: Object, methodName: string) => {
+        let controller = DecoratorRegistry.getOrCreateController(classDefinition.constructor)
+        let endpoint = DecoratorRegistry.getOrCreateEndpoint(controller, methodName)
+
+        if (DecoratorRegistry.getLogger().debugEnabled()) {
+            DecoratorRegistry.getLogger().debug("@apiIgnore() decorator executed for endpoint: %s",
+                endpoint.name)
+        }
+
+        endpoint.apiIgnore = true;
+    }
+}

--- a/src/api/decorator/open-api/apiIgnoreController.ts
+++ b/src/api/decorator/open-api/apiIgnoreController.ts
@@ -1,0 +1,18 @@
+import { DecoratorRegistry } from "../../reflection/DecoratorRegistry"
+
+/**
+ * Decorator for a controller class to describe it in any generated
+ * OpenAPI specification.
+ *
+ * @param name Name of the API used to categorise endpoints in this controller.
+ */
+export function apiIgnoreController() {
+    return (classDefinition: Function) => {
+        let controller = DecoratorRegistry.getOrCreateController(classDefinition)
+
+        DecoratorRegistry.getLogger().debug("@apiIgnore() decorator executed for controller: %s",
+            controller.name)
+
+        controller.apiIgnore = true;
+    }
+}

--- a/src/api/open-api/OpenApiGenerator.ts
+++ b/src/api/open-api/OpenApiGenerator.ts
@@ -227,7 +227,9 @@ export class OpenApiGenerator {
                 this.addTagIfPresent(tags, endpointInfo.controller)
             }
 
-            this.addEndpoint(paths, endpointInfo)
+            if (!endpointInfo.apiIgnore && (endpointInfo.controller && !endpointInfo.controller.apiIgnore)) {
+              this.addEndpoint(paths, endpointInfo)
+            }
         }
     }
 

--- a/src/model/reflection/ControllerInfo.ts
+++ b/src/model/reflection/ControllerInfo.ts
@@ -10,6 +10,7 @@ export class ControllerInfo {
 
     public apiName?: string
     public apiDescription?: string
+    public apiIgnore?: boolean
     public path?: string
     public consumes?: string
     public apiRequestInfo?: ApiBodyInfo

--- a/src/model/reflection/EndpointInfo.ts
+++ b/src/model/reflection/EndpointInfo.ts
@@ -18,6 +18,7 @@ export class EndpointInfo {
     public rolesAllowed?: string[]
     public errorInterceptor?: interfaces.ServiceIdentifier<ErrorInterceptor>
     public apiOperationInfo?: ApiOperationInfo
+    public apiIgnore?: boolean;
 
     public get fullPath() {
         let rootPath = this.getControllerPropOrDefault(c => c.path) || ""

--- a/src/ts-lambda-api.ts
+++ b/src/ts-lambda-api.ts
@@ -22,6 +22,8 @@ export { response } from "./api/decorator/context/parameters/response"
 export { principal } from "./api/decorator/context/parameters/principal"
 
 export { api } from "./api/decorator/open-api/api"
+export { apiIgnoreController } from "./api/decorator/open-api/apiIgnoreController"
+export { apiIgnore } from "./api/decorator/open-api/apiIgnore"
 export { apiOperation } from "./api/decorator/open-api/apiOperation"
 export { apiRequest } from "./api/decorator/open-api/apiRequest"
 export { apiResponse } from "./api/decorator/open-api/apiResponse"

--- a/tests/src/OpenApiTests.ts
+++ b/tests/src/OpenApiTests.ts
@@ -11,7 +11,7 @@ import { TestCustomAuthFilter } from "./test-components/TestCustomAuthFilter";
 
 @TestFixture()
 export class OpenApiTests extends TestBase {
-    private static readonly ROUTE_COUNT = 52
+    private static readonly ROUTE_COUNT = 53
     private static readonly HTTP_METHODS = ["get", "put", "post", "delete", "options", "head", "patch", "trace"]
 
     @Setup
@@ -130,6 +130,27 @@ export class OpenApiTests extends TestBase {
         let tag = response.value.tags.find(t => t.name === "Open API Test")
 
         Expect(tag.description).toBe("Endpoints with OpenAPI decorators")
+    }
+
+    @TestCase("json")
+    @TestCase("yml")
+    @Test()
+    public async when_open_api_enabled_and_controller_is_marked_ignored_then_openapi_spec_does_not_contain_api(specFormat: string) {
+      let response = await this.requestParsedOpenApiSpec(specFormat)
+      let paths = Object.keys(response.value.paths);
+
+      Expect(paths).not.toContain('/test/internal/header')
+    }
+
+    @TestCase("json")
+    @TestCase("yml")
+    @Test()
+    public async when_open_api_enabled_and_endpoint_is_marked_ignored_then_openapi_spec_does_not_contain_endpoint(specFormat: string) {
+      let response = await this.requestParsedOpenApiSpec(specFormat)
+      let paths = Object.keys(response.value.paths);
+
+      Expect(paths).toContain('/test/part-internal/public')
+      Expect(paths).not.toContain('/test/part-internal/private')
     }
 
     @TestCase("json")

--- a/tests/src/test-controllers/IgnoredOpenApiTestController.ts
+++ b/tests/src/test-controllers/IgnoredOpenApiTestController.ts
@@ -1,0 +1,35 @@
+import { injectable } from 'inversify';
+import { apiController, apiIgnoreController, apiIgnore, Controller, GET, header, api} from '../../../dist/ts-lambda-api';
+
+@injectable()
+@apiController("/test/internal")
+@apiIgnoreController()
+export class IgnoredController extends Controller {
+
+    @GET('/header')
+    public privateApi(
+        @header("x-test-header", { description: "test header param" }) test: string,
+    ) {
+        this.response.status(200).send("")
+    }
+}
+
+@injectable()
+@apiController("/test/part-internal")
+export class IgnoredEndpointController extends Controller {
+
+    @GET('/public')
+    public publicApi(
+      @header("x-test-header", { description: "test header param" }) test: string,
+    ) {
+        this.response.status(200).send("")
+    }
+
+    @GET('/private')
+    @apiIgnore()
+    public privateApi(
+      @header("x-test-header", { description: "test header param" }) test: string,
+    ) {
+        this.response.status(200).send("")
+    }
+}

--- a/tests/src/test-controllers/OpenApiTestController.ts
+++ b/tests/src/test-controllers/OpenApiTestController.ts
@@ -1,6 +1,6 @@
 import { injectable } from "inversify"
 
-import { api, apiController, apiOperation, apiRequest, apiResponse, body, header, pathParam, queryParam, rawBody, Controller, JsonPatch, GET, POST, PUT, PATCH, DELETE} from "../../../dist/ts-lambda-api"
+import { api, apiController, apiIgnoreController, apiOperation, apiRequest, apiResponse, body, header, pathParam, queryParam, rawBody, Controller, JsonPatch, GET, POST, PUT, PATCH, DELETE} from "../../../dist/ts-lambda-api"
 
 import { ApiError } from "../test-components/model/ApiError"
 import { ArrayofPrimitivesExample } from '../test-components/model/ArrayOfPrimitivesExample'


### PR DESCRIPTION
We have an API that is intended to be public but also has a few endpoints that are intended to be used internally.  This change adds `@apiIgnoreController` and `@apiIgnore` annotations to allow controllers or individual endpoints to be omitted from the generated OpenAPI spec