### PR TITLE
Path parameters should be enclosed in curly braces for OpenAPI specs

### DIFF
--- a/src/api/open-api/OpenApiGenerator.ts
+++ b/src/api/open-api/OpenApiGenerator.ts
@@ -260,6 +260,8 @@ export class OpenApiGenerator {
             path = path.substring(0, path.length - 1)
         }
 
+        // replace :param with {param} to match OpenAPI spec
+        path = path.replace(/:([^\/]*)(\/?)/g, "{$1}$2");
         let pathInfo: PathItemObject = paths[path] || {}
         let endpointMethod = endpointInfo.httpMethod.toLowerCase()
         let endpointOperation: OperationObject = {

--- a/tests/src/OpenApiTests.ts
+++ b/tests/src/OpenApiTests.ts
@@ -157,7 +157,7 @@ export class OpenApiTests extends TestBase {
     @TestCase("yml")
     @Test()
     public async when_openapi_enabled_then_openapi_spec_contains_parameters(specFormat: string) {
-        let pathEndpoint = await this.getOpenApiEndpoint(specFormat, "/test/path-test/:name/:age", "get")
+        let pathEndpoint = await this.getOpenApiEndpoint(specFormat, "/test/path-test/{name}/{age}", "get")
 
         Expect(pathEndpoint.parameters).toBeDefined()
     }
@@ -166,7 +166,7 @@ export class OpenApiTests extends TestBase {
     @TestCase("yml")
     @Test()
     public async when_openapi_enabled_then_openapi_spec_contains_multiple_parameters(specFormat: string) {
-        let pathEndpoint = await this.getOpenApiEndpoint(specFormat, "/test/path-test/:name/:age", "get")
+        let pathEndpoint = await this.getOpenApiEndpoint(specFormat, "/test/path-test/{name}/{age}", "get")
 
         Expect(pathEndpoint.parameters.length).toBe(2)
     }
@@ -252,7 +252,7 @@ export class OpenApiTests extends TestBase {
     @TestCase("yml")
     @Test()
     public async when_openapi_enabled_then_openapi_spec_contains_path_parameters(specFormat: string) {
-        let pathEndpoint: PathItemObject = await this.getOpenApiEndpoint(specFormat, "/test/path-test/:name/:age", "get")
+        let pathEndpoint: PathItemObject = await this.getOpenApiEndpoint(specFormat, "/test/path-test/{name}/{age}", "get")
         let nameParameter = pathEndpoint.parameters[0] as ParameterObject
         let ageParameter = pathEndpoint.parameters[1] as ParameterObject
 
@@ -271,7 +271,7 @@ export class OpenApiTests extends TestBase {
     @TestCase("yml")
     @Test()
     public async when_openapi_enabled_then_openapi_spec_contains_path_parameters_with_info(specFormat: string) {
-        let pathEndpoint: PathItemObject = await this.getOpenApiEndpoint(specFormat, "/test/open-api/path-info-test/:pathTest", "get")
+        let pathEndpoint: PathItemObject = await this.getOpenApiEndpoint(specFormat, "/test/open-api/path-info-test/{pathTest}", "get")
         let pathParameter = pathEndpoint.parameters[0] as ParameterObject
         let contentSchema = pathParameter.schema
 


### PR DESCRIPTION
The Open API spec requires path parameters to be delimited by curly braces.  The current implementation fails validation because path parameters are prefixed with colon instead. This change replaces occurrences of `/a/:paramB/c` with `/a/{paramB}/c` when generating OpenAPI documentation