### PR TITLE
Examples containing null fields cause an error in OpenApi

### DIFF
--- a/src/api/open-api/OpenApiGenerator.ts
+++ b/src/api/open-api/OpenApiGenerator.ts
@@ -720,6 +720,7 @@ export class OpenApiGenerator {
     }
 
     private getInstanceType(instance: any) : any {
+        if (instance === null || typeof instance === 'undefined') return null;
         let type = ((typeof instance)).toLowerCase()
 
         if (type === "object" && Array.isArray(instance)) {

--- a/tests/src/OpenApiTests.ts
+++ b/tests/src/OpenApiTests.ts
@@ -11,7 +11,7 @@ import { TestCustomAuthFilter } from "./test-components/TestCustomAuthFilter";
 
 @TestFixture()
 export class OpenApiTests extends TestBase {
-    private static readonly ROUTE_COUNT = 53
+    private static readonly ROUTE_COUNT = 54
     private static readonly HTTP_METHODS = ["get", "put", "post", "delete", "options", "head", "patch", "trace"]
 
     @Setup
@@ -762,6 +762,28 @@ export class OpenApiTests extends TestBase {
                 "type": "string",
                 "example": ""
             }
+        })
+    }
+
+    @TestCase("json")
+    @TestCase("yml")
+    @Test()
+    public async when_openapi_enabled_then_openapi_spec_ignores_null_fields(specFormat: string) {
+        let endpoint = await this.getOpenApiEndpoint(specFormat, "/test/open-api/null-fields", "get")
+        let response = endpoint.responses["200"] as ResponseObject
+        let content = response.content["application/json"]
+        let schema = content.schema as SchemaObject
+
+        Expect(schema.type).toEqual("object")
+        Expect(schema.properties).toEqual({
+          "populatedField": {
+            "type": "number",
+            "example": 30
+          },
+          "emptyString": {
+            "type": "string",
+            "example": ""
+          }
         })
     }
 

--- a/tests/src/test-components/model/NullFieldsModel.ts
+++ b/tests/src/test-components/model/NullFieldsModel.ts
@@ -1,0 +1,15 @@
+export class NullFieldsModel {
+    public populatedField: number;
+    public emptyString: string;
+    public nullString: string;
+
+    public static example() {
+        let nullFields = new NullFieldsModel()
+
+        nullFields.populatedField = 30;
+        nullFields.emptyString = "";
+        nullFields.nullString = null;
+
+        return nullFields;
+    }
+}

--- a/tests/src/test-controllers/OpenApiTestController.ts
+++ b/tests/src/test-controllers/OpenApiTestController.ts
@@ -6,6 +6,7 @@ import { ApiError } from "../test-components/model/ApiError"
 import { ArrayofPrimitivesExample } from '../test-components/model/ArrayOfPrimitivesExample'
 import { ConstructorOnlyModel } from "../test-components/model/ConstructorOnlyModel"
 import { EdgeCaseModel } from "../test-components/model/EdgeCaseModel"
+import { NullFieldsModel } from '../test-components/model/NullFieldsModel'
 import { People } from "../test-components/model/People"
 import { Person } from "../test-components/model/Person"
 import { PrimitiveExample } from '../test-components/model/PrimitiveExample'
@@ -61,6 +62,13 @@ export class OpenApiTestControllerController extends Controller {
     @apiResponse(200, {class: EdgeCaseModel})
     public getEdgeCase() {
         return new EdgeCaseModel()
+    }
+
+    @GET("/null-fields")
+    @apiOperation({ name: "get null fields stuff", description: "go get some null fields stuff"})
+    @apiResponse(200, {class: NullFieldsModel})
+    public getNullFields() {
+        return new NullFieldsModel()
     }
 
     @POST()


### PR DESCRIPTION
When using the `example()` method for classes in OpenApi responses, any fields containing null cause an error

```
ERROR Endpoint - [GET] /open-api.json - Error occurred in method 'internal__openapi::json' in controller '<dynamic>'
TypeError: Cannot convert undefined or null to object
```

This patch ensures the nulls do not cause an error, and are simply excluded from the schema.