### PR TITLE
fix import to allow inversify 5.1.1 to be used

### DIFF
--- a/src/api/decorator/error/errorInterceptor.ts
+++ b/src/api/decorator/error/errorInterceptor.ts
@@ -1,6 +1,6 @@
 import { inspect } from "util"
 
-import { interfaces } from "inversify/dts/interfaces/interfaces"
+import { interfaces } from "inversify"
 
 import { LogLevel } from "../../../model/logging/LogLevel"
 import { ErrorInterceptor } from "../../error/ErrorInterceptor"


### PR DESCRIPTION
Hello,
I had issue when building my project with version 2.2.3, and realised it's because npm used inversify 5.1.1 (latest)
I suggest this fix