### PR TITLE
Update OpenApiGenerator.ts

### DIFF
--- a/src/api/open-api/OpenApiGenerator.ts
+++ b/src/api/open-api/OpenApiGenerator.ts
@@ -1,4 +1,4 @@
-import { OpenApiBuilder } from "openapi3-ts/oas31"
+import { OpenApiBuilder } from "openapi3-ts/dist/oas31"
 import {
     ContentObject,
     MediaTypeObject,


### PR DESCRIPTION
I got an error when test rest api with jest. I got an error then i found that the import isn't direct to dist folder. So i change the import to dist folder.

I'm using:
Typescript: v4.9.3
OS: Linux Ubuntu 22
Node: 18.17.1

here'a the error:
![image](https://github.com/djfdyuruiry/ts-lambda-api/assets/15315990/627d4019-8da4-48ff-ac2c-e771339419f6)

Here's example code of my unit test:
`describe("Test Blacklist Controller", () => {
  let appConfig: AppConfig;
  let app: ApiLambdaApp;
  const presharedKey = "k0katt0pr3shar3dk3y";
  let container;
  const model = {
    blacklist: {
      clientId: "8002",
      mediaType: "SMS",
      intlPhoneNumber: "081322084991",
    },
  };

  beforeEach(() => {
    appConfig = appConfig || new AppConfig();
    appConfig.serverLogger = {
      level: LogLevel.trace,
    };

    appConfig.logger = {
      level: "trace",
    };

    container = prepareContainer(model);

    app = new ApiLambdaApp([path.join(__dirname, "..", "..", "..", "src", "controllers")], appConfig, container);
  });

  it("does create blacklist entry successfully", async (done) => {
    const request = {
      httpMethod: "POST",
      path: "/blacklist",
      headers: {
        authorization: "bearer 123SAD",
      },
      queryStringParameters: {},
      body: JSON.stringify({
        clientId: "8002",
        mediaType: "SMS",
        intlPhoneNumber: "08132208991",
      }),
      isBase64Encoded: false,
    };

    const response = await app.run(request, {});
    expect(response.statusCode).toEqual(200);
    done();
  }, 5000);
});`
